### PR TITLE
Add slsReceiver and slsDetector targets to the export set (used by downwstream project)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set (CALIBRATE OFF)
 
+# Check if project is being used directly or via add_subdirectory
+set(SLS_MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+	set(SLS_MASTER_PROJECT ON)
+endif()
+
 option (USE_HDF5 "HDF5 File format" OFF)
 option (USE_TEXTCLIENT "Text Client" OFF)
 option (USE_RECEIVER "Receiver" OFF)
@@ -42,6 +48,10 @@ if (USE_GUI)
        endif()
 endif (USE_GUI)
 
+if (SLS_MASTER_PROJECT)
+	# Set targets export name (otherwise set by upstream project)
+	set(TARGETS_EXPORT_NAME "slsdetector-targets")
+endif (SLS_MASTER_PROJECT)
 
 if (CALIBRATE)
     if (DEFINED ENV{ROOTSYS})

--- a/slsDetectorSoftware/CMakeLists.txt
+++ b/slsDetectorSoftware/CMakeLists.txt
@@ -93,6 +93,7 @@ if(DOXYGEN_FOUND)
 endif()
 
 install(TARGETS slsDetectorShared slsDetectorStatic
+    EXPORT "${TARGETS_EXPORT_NAME}"
     LIBRARY DESTINATION lib
     PUBLIC_HEADER DESTINATION include
     ARCHIVE DESTINATION lib)

--- a/slsReceiverSoftware/CMakeLists.txt
+++ b/slsReceiverSoftware/CMakeLists.txt
@@ -101,6 +101,7 @@ endif ()
 
 
 install(TARGETS slsReceiverShared slsReceiverStatic slsReceiver
+        EXPORT "${TARGETS_EXPORT_NAME}"
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib


### PR DESCRIPTION
Sorry for the reformating, was not intended. Let me know if you want me to fix this. The meaningful change is **EXPORT "${TARGETS_EXPORT_NAME}"** in:

```
install(TARGETS a b c
    EXPORT "${TARGETS_EXPORT_NAME}"
    LIBRARY DESTINATION lib
```